### PR TITLE
Add missing fs-extra dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For usage information:
 git-http-server2 --help
 ```
 
-Options can be controlled via the command-line (highest precedence) or 
+Options can be controlled via the command-line (highest precedence) or
 environment variables. These are also describe in the usage message:
 
 ```
@@ -51,13 +51,14 @@ usage: git-http-server2 [-r] [-p port] [-H host] [dir]
 
 options
 
-  -h, --help          print this message and exit
-  -i, --ip            [env GIT_HTTP_IP] IP address of the allowed client
-  -H, --host <host>   [env GIT_HTTP_HOST] host on which to listen
-  -p, --port <port>   [env GIT_HTTP_PORT] port on which to listen
-  -r, --readonly      [env GIT_HTTP_READONLY] operate in read-only mode
-  -u, --updates       check for available updates and exit
-  -v, --version       print the version number and exit
+  -h, --help           print this message and exit
+  -i, --ip             [env GIT_HTTP_IP] IP address of the allowed client
+  -H, --host <host>    [env GIT_HTTP_HOST] host on which to listen
+  -p, --port <port>    [env GIT_HTTP_PORT] port on which to listen
+  -r, --readonly       [env GIT_HTTP_READONLY] operate in read-only mode
+  -a, --allowcreation [env GIT_HTTP_ALLOWCREATION] allows pushing unknown repositories
+  -u, --updates        check for available updates and exit
+  -v, --version        print the version number and exit
 ```
 
 ## Examples

--- a/main.js
+++ b/main.js
@@ -54,8 +54,8 @@ var server = module.exports = {
 
 
     function started() {
-      console.log('listening on http://%s:%d in %s', 
-        opts.host, opts.port, process.cwd());
+      console.log('listening on http://%s:%d in %s',
+        opts.host, opts.port, opts.dir);
     }
 
     function onrequest(req, res) {

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ var server = module.exports = {
         fs.accessSync(dir, fs.F_OK);
       }
       catch(err) {
+        console.log(dir + ' does not exist, creating');
         fs.mkdirpSync(dir);
       }
       process.chdir(dir);

--- a/main.js
+++ b/main.js
@@ -166,6 +166,7 @@ if (!module.parent) (function() {
   }
   var args = process.argv.slice(parser.optind());
   var dir = args[0];
+  cmdOpts.dir = dir
 
   server.run(cmdOpts);
 })();

--- a/main.js
+++ b/main.js
@@ -63,9 +63,9 @@ var server = module.exports = {
 
     function onrequest(req, res) {
       accesslog(req, res);
-      var ip = req.ip || 
-        req.connection.remoteAddress || 
-        req.socket.remoteAddress || 
+      var ip = req.ip ||
+        req.connection.remoteAddress ||
+        req.socket.remoteAddress ||
         req.connection.socket.remoteAddress;
       if (ip != '127.0.0.1' && !(opts.ip && opts.ip == ip)) {
         console.error('Request from bad ip: ' + ip);
@@ -90,7 +90,7 @@ var server = module.exports = {
         console.error('no .git in path: ' + u.pathname);
         res.statusCode = 400;
         res.end();
-        return;        
+        return;
       }
       var repo = segs.slice(1, gi + 1).join('/')
       //var repo = u.pathname.split('/')[1];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "access-log": "^0.3.9",
+    "fs-extra": "^2.1.2",
     "git-http-backend": "^1.0.0",
     "latest": "^0.2.0",
     "posix-getopt": "^1.2.0"


### PR DESCRIPTION
Otherwise:

```
npm install -g git-http-server2
git-http-server2
module.js:472
    throw err;
    ^

Error: Cannot find module 'fs-extra'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/git-http-server2/main.js:10:10)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```