### PR TITLE
Allow `args[0]` as directory to watch

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,8 +54,8 @@ var server = module.exports = {
 
 
     function started() {
-      console.log('listening on http://%s:%d in %s', 
-        opts.host, opts.port, process.cwd());
+      console.log('listening on http://%s:%d in %s',
+        opts.host, opts.port, opts.dir);
     }
 
     function onrequest(req, res) {

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ var server = module.exports = {
         fs.accessSync(dir, fs.F_OK);
       }
       catch(err) {
+        console.log(dir + ' does not exist, creating');
         fs.mkdirpSync(dir);
       }
       process.chdir(dir);

--- a/main.js
+++ b/main.js
@@ -166,6 +166,7 @@ if (!module.parent) (function() {
   }
   var args = process.argv.slice(parser.optind());
   var dir = args[0];
+  cmdOpts.dir = dir
 
   server.run(cmdOpts);
 })();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "access-log": "^0.3.9",
+    "fs-extra": "^2.1.2",
     "git-http-backend": "^1.0.0",
     "latest": "^0.2.0",
     "posix-getopt": "^1.2.0"


### PR DESCRIPTION
This includes #1 (otherwise testing is hard)

I found that passing the directory to watch, actually did not work as advertised, as the option was never passed to the options.

Also added some logging.